### PR TITLE
replication: handle multiple PARTIAL_UPDATE_ROWS_EVENT diffs

### DIFF
--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -560,42 +560,49 @@ func (d *jsonBinaryDecoder) decodeVariableLength(data []byte) (int, int) {
 	return 0, 0
 }
 
-func (e *RowsEvent) decodeJsonPartialBinary(data []byte) (*JsonDiff, error) {
-	// see Json_diff_vector::read_binary() in mysql-server/sql/json_diff.cc
-	operationNumber := JsonDiffOperation(data[0])
-	switch operationNumber {
-	case JsonDiffOperationReplace:
-	case JsonDiffOperationInsert:
-	case JsonDiffOperationRemove:
-	default:
-		return nil, ErrCorruptedJSONDiff
+func (e *RowsEvent) decodeJsonPartialBinary(data []byte) ([]JsonDiff, error) {
+	var diffs []JsonDiff
+
+	for len(data) > 0 {
+		// see Json_diff_vector::read_binary() in mysql-server/sql/json_diff.cc
+		operationNumber := JsonDiffOperation(data[0])
+		switch operationNumber {
+		case JsonDiffOperationReplace:
+		case JsonDiffOperationInsert:
+		case JsonDiffOperationRemove:
+		default:
+			return nil, ErrCorruptedJSONDiff
+		}
+		data = data[1:]
+
+		pathLength, _, n := mysql.LengthEncodedInt(data)
+		data = data[n:]
+
+		path := data[:pathLength]
+		data = data[pathLength:]
+
+		if operationNumber == JsonDiffOperationRemove {
+			diffs = append(diffs, JsonDiff{
+				Op:   operationNumber,
+				Path: string(path),
+			})
+			continue
+		}
+
+		valueLength, _, n := mysql.LengthEncodedInt(data)
+		data = data[n:]
+
+		d, err := e.decodeJsonBinary(data[:valueLength])
+		if err != nil {
+			return nil, fmt.Errorf("cannot read json diff for field %q: %w", path, err)
+		}
+		data = data[valueLength:]
+		diffs = append(diffs, JsonDiff{
+			Op:    operationNumber,
+			Path:  string(path),
+			Value: string(d),
+		})
 	}
-	data = data[1:]
 
-	pathLength, _, n := mysql.LengthEncodedInt(data)
-	data = data[n:]
-
-	path := data[:pathLength]
-	data = data[pathLength:]
-
-	diff := &JsonDiff{
-		Op:   operationNumber,
-		Path: string(path),
-		// Value will be filled below
-	}
-
-	if operationNumber == JsonDiffOperationRemove {
-		return diff, nil
-	}
-
-	valueLength, _, n := mysql.LengthEncodedInt(data)
-	data = data[n:]
-
-	d, err := e.decodeJsonBinary(data[:valueLength])
-	if err != nil {
-		return nil, fmt.Errorf("cannot read json diff for field %q: %w", path, err)
-	}
-	diff.Value = string(d)
-
-	return diff, nil
+	return diffs, nil
 }

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1437,12 +1437,12 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16, isPartial boo
 			v = []byte{}
 		} else {
 			if isPartial {
-				var diff *JsonDiff
-				diff, err = e.decodeJsonPartialBinary(data[meta:n])
+				var diffs []JsonDiff
+				diffs, err = e.decodeJsonPartialBinary(data[meta:n])
 				if err == nil {
-					v = diff
+					v = diffs
 				} else {
-					fmt.Printf("decodeJsonPartialBinary(%q) fail: %s\n", data[meta:n], err)
+					err = fmt.Errorf("decodeJsonPartialBinary(%q) fail: %s\n", data[meta:n], err)
 				}
 			} else {
 				var d []byte


### PR DESCRIPTION
The logic for PARTIAL_UPDATE_ROWS_EVENT handling introduced in April 2023 by commit 3d2be208 is incorrect because it assumes a partial JSON update can only ever patch one location in the JSON column value. This is not the case, so the correct representation of a partial update value is a list of multiple diffs and the parsing logic needs to loop until all diffs have been decoded.

I have not given much thought to migration here. Arguably it may be helpful to add a special case so that a single-location diff still results in a `*JsonDiff` value, but on the other hand that is of limited usefulness because any consumers of partial JSON diffs need to handle the multiple-patch case to be correct anyway and if they're going to add proper handling then that special case just forces the recipient to duplicate the value processing logic.